### PR TITLE
Fix crash in context initialization when argc == 0

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -66,8 +66,8 @@ static int str_format(char* buf, size_t buf_size, const char* fmt, ...)
 
 int getopt_create_context( getopt_context_t* ctx, int argc, const char** argv, const getopt_option_t* opts )
 {
-	ctx->argc            = argc - 1; /* stripping away file-name! */
-	ctx->argv            = argv + 1; /* stripping away file-name! */
+	ctx->argc            = (argc > 1) ? (argc - 1) : 0; /* stripping away file-name! */
+	ctx->argv            = (argc > 1) ? (argv + 1) : argv; /* stripping away file-name! */
 	ctx->opts            = opts;
 	ctx->current_index   = 0;
 	ctx->current_opt_arg = 0x0;

--- a/test/getopt_tests.cpp
+++ b/test/getopt_tests.cpp
@@ -163,6 +163,30 @@ int test_missing_arg( int argc, const char** argv )
 	return 0;
 }
 
+int test_zero_args( int argc, const char** argv )
+{
+	getopt_context_t ctx;
+	int err = getopt_create_context( &ctx, argc, argv, option_list );
+	ASSERT_EQ( 0, err );
+
+	int opt;
+	if( ( opt = getopt_next( &ctx ) ) != -1 )
+	{
+		FAILm("No arguments should have been parsed since argc was 0!");
+	}
+
+	return 0;
+}
+
+TEST with_zero_args()
+{
+	if (test_zero_args( 0, NULL ) != 0 ) return -1;
+	if (test_zero_args( 1, NULL ) != 0 ) return -1;
+	return 0;
+}
+
+
+
 TEST with_args_short()
 {
 	const char* argv[] = { "dummy_prog", "-c", "c_value_1", "-c", "c_value_2" };
@@ -331,6 +355,7 @@ GREATEST_SUITE( getopt )
 	RUN_TEST( optional_arg );
 	RUN_TEST( non_arguments );
 	RUN_TEST( set_flag );
+	RUN_TEST( with_zero_args );
 }
 
 GREATEST_MAIN_DEFS();


### PR DESCRIPTION
This PR fixes a crash when `getopt_create_context` is passed `0` in `argc`, and adds some tests to validate the fix.

I'm not sure if this is the best possible way to handle this case, but the fix is concise and safe.