### PR TITLE
 Allow getopt_option_t::value to be zero

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -80,7 +80,6 @@ int getopt_create_context( getopt_context_t* ctx, int argc, const char** argv, c
 		if( opt->value == '!' || 
 			opt->value == '?' || 
 			opt->value == '+' || 
-			opt->value ==  0  || 
 			opt->value == -1)
 			return -1;
 

--- a/test/getopt_tests.cpp
+++ b/test/getopt_tests.cpp
@@ -40,6 +40,7 @@ static const getopt_option_t option_list[] =
 	{ "eeee", 'e', GETOPT_OPTION_TYPE_FLAG_SET, &g_flag, 1337, "help e", 0 },
 	{ "ffff", 'f', GETOPT_OPTION_TYPE_FLAG_AND, &g_flag,    1, "help f", 0 },
 	{ "gggg", 'g', GETOPT_OPTION_TYPE_FLAG_OR , &g_flag,    1, "help g", 0 },
+	{ "hhhh", 'h', GETOPT_OPTION_TYPE_NO_ARG,   0x0,        0, "help h", 0 },
 	GETOPT_OPTIONS_END
 };
 


### PR DESCRIPTION
This PR fixes a bug where a `getopt_option_t` with `value` of 0 fails in `getopt_create_context` in the opt count, despite not having any reason to be a reserved value.

This makes the following case fail to function:
```c++
enum Args {
    ARG_A, // this is the 0 value
    ARG_B,
    ARG_C,
};

static getopt_option_t opts[] =
{
	{ "arga", 'a', GETOPT_OPTION_TYPE_NO_ARG, 0x0, ARG_A, "help a", 0x0 },
	{ "argb", 'b', GETOPT_OPTION_TYPE_NO_ARG, 0x0, ARG_B, "help b", 0x0 },
	{ "argc", 'c', GETOPT_OPTION_TYPE_NO_ARG, 0x0, ARG_C, "help c", 0x0 },
	GETOPT_OPTIONS_END
};

int main(int argc, const char **argv)
{
	int res = getopt_create_context( &ctx, argc, argv, opts );
	ASSERT( res >= 0 ); // fails here, getopt_create_context returns -1
}
```

I have also modified tests to validate that a value of `0` functions.
