### PR TITLE
Remove superfluous option count calculation

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -87,8 +87,6 @@ int getopt_create_context( getopt_context_t* ctx, int argc, const char** argv, c
 		ctx->num_opts++; opt++;
 	}
 
-	ctx->num_opts = (int)(opt - opts);
-
 	return 0;
 }
 


### PR DESCRIPTION
Option count is computed from `getopt_create_context` twice, so I removed one for clarity.