### PR TITLE
Add meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,13 @@
+project('getopt', 'c', default_options : ['c_std=c99'])
+
+libgetopt_include = include_directories('include')
+libgetopt = library('getopt', 'src/getopt.c', include_directories: libgetopt_include, install: true)
+install_headers('include/getopt/getopt.h', subdir: 'getopt')
+
+pkg = import('pkgconfig')
+pkg.generate(libgetopt,
+    filebase : 'getopt',
+    name : 'getopt',
+    description : 'C library to parse command-line options',
+    url : 'github.com/wc-duck/getopt',
+)


### PR DESCRIPTION
Add a simple but effective Meson build file. Installs correctly the library and header file and add a pkg-config file.